### PR TITLE
Wait with input parsing to the end of data stream

### DIFF
--- a/src/diff/differ.js
+++ b/src/diff/differ.js
@@ -31,10 +31,10 @@ const differ = function( repoRelativeDirectory, targetBranch = 'master', current
 			gitProcess.on( 'close', ( code, signal ) => {
 				const data = bufferedGitOutput.join( '' );
 
-				const filesStatus = parseGitOutput( data.toString() );
+				const filesStatus = parseGitOutput( data );
 				const dependencyMap = getDependencyMap( path.join( repoRelativeDirectory, 'plugins/' ) );
 
-				const benderFilters = convertFilesStatusIntoBenderFilter( filesStatus, dependencyMap );	
+				const benderFilters = convertFilesStatusIntoBenderFilter( filesStatus, dependencyMap );
 
 				resolve( benderFilters );
 			} );


### PR DESCRIPTION
Output from the git diff command was parsed immediately after receiving the chunk of data. But if the diff output was big enough the chunk may be 'cut' in an unexpected place, like in the middle of the file path.
Current version process the first chunk in a correct way (abstaining of a cut file path). However, the second chunk is not started from status but from the ending of the previously cut path. So instead of patterns like:
```status\tfilePath\n```
we are processing in the first chunk:
```status\tfileP``` 
and in the second
```ath\nstatus\tanotherFilePath```

The fix here, just to gather all incoming chunks into the array and then joins it into a single large string. Only then, this data is passed to our parser.

I tried to create some test for that with stubbing child_process.spawn method (using Sinon) but I found it PITA and since this is side repository, maybe we could take it without the test?

Please be aware, that I added logs directly to the master branch: https://github.com/ckeditor/ckeditor4-benderjs-runner/commit/31a7fa68f8bdbd0781dbd7984ee7431e90c280a1 because git diff output comes chunked only on CI. For the same branches, locally on my PC they come in as one big chunk of data. After merging this PR and verify that CI is working fine again, we can remove them.

Closes: #20 