### PR TITLE
Add fifth paramter: repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ npm i
 
 _You can change `bender-runner.config.json` config `paths.ckeditor4` property to point to your current CKEditor 4 directory or pass repository path as fifth argument in CLI instead of cloning `ckeditor4` repository_.
 
+
 3. Go back to main repo dir and run:
 
 ```bash
@@ -113,6 +114,12 @@ Another flag can be passed to force full test run - no matter the diff between b
 
 ```bash
 npm run start '../bender-runner.config.json' 'master' 'major' 'chrome' 'fullRun'
+```
+
+Path to the `ckeditor4` directory can be passed in the last position:
+
+```bash
+npm run start '../bender-runner.config.json' 'master' 'major' 'chrome' 'fullRun' '../ckeditor4'
 ```
 
 ## Bender filters generator

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd ckeditor4
 npm i
 ```
 
-_You can also change `bender-runner.config.json` config `paths.ckeditor4` property to point to your current CKEditor 4 directory instead of cloning `ckeditor4` repository_.
+_You can change `bender-runner.config.json` config `paths.ckeditor4` property to point to your current CKEditor 4 directory or pass repository path as fifth argument in CLI instead of cloning `ckeditor4` repository_.
 
 3. Go back to main repo dir and run:
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,6 +9,12 @@ const config = require( `./${ args[ 0 ] }` );
 const targetBranch = args[ 1 ];
 const currentBranch = args[ 2 ];
 const fullRun = !!( args[ 4 ] );
+const repoPath = args[ 5 ];
+
+// Repo path incoming from CLI has priority over json config
+if ( repoName ) {
+	config.paths.ckeditor4 = repoPath;
+}
 
 console.log( `Loaded config from ${ args[ 0 ] }` );
 


### PR DESCRIPTION
I added the fifth parameter: path to ckeditor4 repository path. If the cfg appears in CLI - it will override json config.

It's needed to have a unifed config settings between various repositories.